### PR TITLE
feat: Implement 'shoot again on hit' and add tests

### DIFF
--- a/battleship/internal/application/board.go
+++ b/battleship/internal/application/board.go
@@ -28,6 +28,7 @@ type BattleshipBoard interface {
 	ddd.Board[uint8]
 	SeedBoard()
 	Attack(x, y int) (hit, sunk bool, err error)
+	PlaceShip(x int, y int, shipType uint8, orientation uint8) bool
 }
 
 type battleshipBoard struct {

--- a/battleship/internal/application/board_test.go
+++ b/battleship/internal/application/board_test.go
@@ -1,0 +1,79 @@
+package application
+
+import (
+	"testing"
+)
+
+func TestAttack_Hit(t *testing.T) {
+	board := newBattleshipBoard(10, 10)
+	board.PlaceShip(0, 0, Destroyer, Horizontal)
+
+	hit, sunk, err := board.Attack(0, 0)
+
+	if err != nil {
+		t.Errorf("Expected no error, but got %v", err)
+	}
+	if !hit {
+		t.Error("Expected hit to be true, but got false")
+	}
+	if sunk {
+		t.Error("Expected sunk to be false, but got true")
+	}
+	if coord := board.Coordinate(0, 0); coord != Hit {
+		t.Errorf("Expected coordinate to be %v, but got %v", Hit, coord)
+	}
+}
+
+func TestAttack_Miss(t *testing.T) {
+	board := newBattleshipBoard(10, 10)
+
+	hit, sunk, err := board.Attack(0, 0)
+
+	if err != nil {
+		t.Errorf("Expected no error, but got %v", err)
+	}
+	if hit {
+		t.Error("Expected hit to be false, but got true")
+	}
+	if sunk {
+		t.Error("Expected sunk to be false, but got true")
+	}
+	if coord := board.Coordinate(0, 0); coord != Miss {
+		t.Errorf("Expected coordinate to be %v, but got %v", Miss, coord)
+	}
+}
+
+func TestAttack_Invalid(t *testing.T) {
+	board := newBattleshipBoard(10, 10)
+	board.Attack(0, 0) // First attack
+
+	hit, sunk, err := board.Attack(0, 0) // Second attack on the same cell
+
+	if err == nil {
+		t.Error("Expected an error, but got nil")
+	}
+	if hit {
+		t.Error("Expected hit to be false, but got true")
+	}
+	if sunk {
+		t.Error("Expected sunk to be false, but got true")
+	}
+}
+
+func TestAttack_Sunk(t *testing.T) {
+	board := newBattleshipBoard(10, 10)
+	board.PlaceShip(0, 0, Destroyer, Horizontal) // Destroyer has length 2
+
+	board.Attack(0, 0)
+	hit, sunk, err := board.Attack(1, 0)
+
+	if err != nil {
+		t.Errorf("Expected no error, but got %v", err)
+	}
+	if !hit {
+		t.Error("Expected hit to be true, but got false")
+	}
+	if !sunk {
+		t.Error("Expected sunk to be true, but got false")
+	}
+}

--- a/battleship/module.go
+++ b/battleship/module.go
@@ -169,9 +169,10 @@ func (g *game) handleClick() {
 
 			if err != nil {
 				fmt.Println("Error: ", err)
-			} else {
+			} else if !hit {
 				g.isPlayerTurn = false
 			}
+
 			if hit {
 				fmt.Println("Hit!")
 			}


### PR DESCRIPTION
This commit introduces two main changes to the battleship game:

1.  The game logic is updated to allow the player to take another turn after a successful hit. If the player's attack is a miss, the turn switches to the AI. If the attack is invalid (e.g., attacking the same spot twice), the player gets to attack again.

2.  Basic unit tests have been added for the battleship board logic using the standard `testing` package. These tests cover scenarios for hits, misses, invalid attacks, and sinking a ship.